### PR TITLE
Change vNodes.empty() to vNodes.size() < 3

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -542,7 +542,7 @@ void ThreadStakeMiner(CWallet *pwallet)
             MilliSleep(1000);
         }
 
-        while (vNodes.empty() || IsInitialBlockDownload())
+        while (vNodes.size() < 3 || IsInitialBlockDownload())
         {
             nLastCoinStakeSearchInterval = 0;
             fTryToSync = true;


### PR DESCRIPTION
Checking for vNodes.empty() or IsInitialBlockDownload() isn't enough of a check for the nodes. if the list isn't empty it skips the check for the size of the list. causing it to stake with less than 3 nodes.